### PR TITLE
Don’t do spacemacs things when people don’t use spacemacs.

### DIFF
--- a/pymupdf-mode.el
+++ b/pymupdf-mode.el
@@ -200,8 +200,8 @@ process buffer for a list of commands.)"
   (pymupdf-mode 0)
   (pymupdf-mode 1))
 
-(spacemacs/declare-prefix-for-mode 'pdf-view-mode "mt" "toggles")
-(spacemacs/set-leader-keys-for-major-mode 'pdf-view-mode "tp" 'pymupdf-mode)
+(when (fboundp 'spacemacs/declare-prefix-for-mode) (spacemacs/declare-prefix-for-mode 'pdf-view-mode "mt" "toggles"))
+(when (fboundp 'spacemacs/set-leader-keys-for-major-mode) (spacemacs/set-leader-keys-for-major-mode 'pdf-view-mode "tp" 'pymupdf-mode))
 
 ;;;###autoload
 (define-minor-mode pymupdf-mode


### PR DESCRIPTION
Emacs won?t stop screaming about ?Symbol?s function definition is void? so
this will fix my personal annoyance. 

I'm sure there's probably a more elegant way to check for spacemacs but this will do.

Also, do you think that I can incorporate this into [EAF](https://github.com/manateelazycat/emacs-application-framework)'s pdf-viewer? It also uses pymupdf so that might be pretty easy.